### PR TITLE
Add more endpoints for Answer Entity

### DIFF
--- a/src/main/scala/com/voombua/ServiceMain.scala
+++ b/src/main/scala/com/voombua/ServiceMain.scala
@@ -5,13 +5,13 @@ import akka.event.Logging
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
 import akka.stream.ActorMaterializer
-import com.voombua.core.{AnswerService, AuthService, QuestionService}
-import com.voombua.models.{AnswerComponent, QuestionComponent, UserComponent}
-import com.voombua.repos.{DB, PG}
+import com.voombua.core.{ AnswerService, AuthService, QuestionService }
+import com.voombua.models.{ AnswerComponent, QuestionComponent, UserComponent }
+import com.voombua.repos.{ DB, PG }
 import com.voombua.routes.HttpRoute
-import com.voombua.utils.{Config, MigrationConfig}
+import com.voombua.utils.{ Config, MigrationConfig }
 
-import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.concurrent.{ ExecutionContextExecutor, Future }
 
 object ServiceMain extends App with Config with MigrationConfig with UserComponent with DB with PG with QuestionComponent
     with AnswerComponent {

--- a/src/main/scala/com/voombua/core/AnswerService.scala
+++ b/src/main/scala/com/voombua/core/AnswerService.scala
@@ -4,8 +4,9 @@ import java.sql.Timestamp
 import java.time.Instant
 import java.util.UUID
 
-import com.voombua.messages.AnswerMessage
+import com.voombua.messages.{ AnswerMessage, AnswerUpdateMessage }
 import com.voombua.models.{ Answer, AnswerComponent }
+import com.voombua.utils.MonadTransformers._
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -13,5 +14,12 @@ class AnswerService(answerStorage: AnswerComponent#AnswersRepository)(implicit e
   def postAnswer(request: AnswerMessage, questionId: QuestionId, userId: UserId): Future[Answer] = {
     answerStorage.saveAnswer(Answer(UUID.randomUUID().toString, questionId, userId, request.content,
       Timestamp.from(Instant.now()), None, None))
+  }
+
+  def updateAnswer(answerId: AnswerId, request: AnswerUpdateMessage): Future[Option[Answer]] = {
+    answerStorage
+      .findAnswer(answerId)
+      .mapT(request.merge)
+      .flatMapTOuter(answerStorage.saveAnswer)
   }
 }

--- a/src/main/scala/com/voombua/mapping/JsonSupport.scala
+++ b/src/main/scala/com/voombua/mapping/JsonSupport.scala
@@ -5,7 +5,7 @@ import java.time.Instant
 import java.util.UUID
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import com.voombua.messages._
+import com.voombua.messages.{ AnswerUpdateMessage, _ }
 import com.voombua.models.{ Answer, Question, User }
 import spray.json.{ DefaultJsonProtocol, JsNumber, JsString, JsValue, JsonFormat, RootJsonFormat }
 
@@ -45,4 +45,5 @@ trait JsonProtocol extends SprayJsonSupport with BaseJsonProtocol {
   implicit val questionUpdateMessageFormat: RootJsonFormat[QuestionUpdateMessage] = jsonFormat3(QuestionUpdateMessage)
   implicit val answerFormat: RootJsonFormat[Answer] = jsonFormat7(Answer)
   implicit val answerMessageFormat: RootJsonFormat[AnswerMessage] = jsonFormat1(AnswerMessage)
+  implicit val answerUpdateMessage: RootJsonFormat[AnswerUpdateMessage] = jsonFormat1(AnswerUpdateMessage)
 }

--- a/src/main/scala/com/voombua/messages/AnswerUpdateMessage.scala
+++ b/src/main/scala/com/voombua/messages/AnswerUpdateMessage.scala
@@ -1,0 +1,14 @@
+package com.voombua.messages
+
+import java.sql.Timestamp
+import java.time.Instant
+
+import com.voombua.models.Answer
+
+case class AnswerUpdateMessage(content: Option[String]) {
+  def merge(answer: Answer): Answer = {
+    Answer(answer.id, answer.questionId, answer.userId, content.getOrElse(answer.content), answer.created,
+      Some(Timestamp.from(Instant.now())), None)
+  }
+
+}

--- a/src/main/scala/com/voombua/models/AnswerComponent.scala
+++ b/src/main/scala/com/voombua/models/AnswerComponent.scala
@@ -1,9 +1,9 @@
 package com.voombua.models
 
-import com.voombua.core.QuestionId
-import com.voombua.repos.{DB, RepoDefinition}
+import com.voombua.core.{ AnswerId, QuestionId, UserId }
+import com.voombua.repos.{ DB, RepoDefinition }
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
 trait AnswerComponent extends RepoDefinition with QuestionComponent {
   this: DB ⇒
@@ -34,6 +34,11 @@ trait AnswerComponent extends RepoDefinition with QuestionComponent {
     override def saveAnswer(answer: Answer): Future[Answer] =
       db.run(table.insertOrUpdate(answer)).map(_ => answer)
 
+    override def findAnswer(answerId: AnswerId): Future[Option[Answer]] =
+      db.run(table.filter(_.id === answerId).result.headOption)
+
+    override def deleteAnswer(answerId: AnswerId, questionId: QuestionId, userId: UserId): Future[Int] =
+      db.run(table.filter(res ⇒ res.id === answerId && res.questionId === questionId && res.userId === userId).delete)
   }
 
 }
@@ -42,4 +47,6 @@ sealed trait AnswerDAO {
   def findAllAnswers(): Future[Seq[Answer]]
   def findAllAnswersToQuestion(questionId: QuestionId): Future[Seq[Answer]]
   def saveAnswer(answer: Answer): Future[Answer]
+  def findAnswer(answerId: AnswerId): Future[Option[Answer]]
+  def deleteAnswer(answerId: AnswerId, questionId: QuestionId, userId: UserId): Future[Int]
 }

--- a/src/main/scala/com/voombua/models/QuestionComponent.scala
+++ b/src/main/scala/com/voombua/models/QuestionComponent.scala
@@ -38,7 +38,7 @@ trait QuestionComponent extends RepoDefinition with UserComponent { this: DB ⇒
     }
 
     override def deleteQuestion(questionId: QuestionId, userId: UserId): Future[Int] =
-      db.run(table.filter(question ⇒ question.id === questionId || question.userId === userId).delete)
+      db.run(table.filter(question ⇒ question.id === questionId && question.userId === userId).delete)
 
     override def saveQuestion(question: Question): Future[Question] =
       db.run(table.insertOrUpdate(question)).map(_ => question)

--- a/src/main/scala/com/voombua/routes/HttpRoute.scala
+++ b/src/main/scala/com/voombua/routes/HttpRoute.scala
@@ -13,7 +13,7 @@ class HttpRoute(authService: AuthService, questionService: QuestionService,
     questionRepo: QuestionComponent#QuestionRepository, ansService: AnswerService,
     answerRepo: AnswerComponent#AnswersRepository)(implicit ec: ExecutionContext) {
   private val userRoutes: UserRoutes = new UserRoutes(userRepo, authService)
-  private val questionRoute: QuestionRoute = new QuestionRoute(secretKey, questionRepo, questionService, ansService)
+  private val questionRoute: QuestionRoute = new QuestionRoute(secretKey, questionRepo, questionService, ansService, answerRepo)
 
   val route: Route =
     cors() {


### PR DESCRIPTION
#### What does this PR do?
- Adds `update` and `delete` endpoints
- Refactors the delete logic for Question and Answer Entity.
- Adds `updateAnswer` functionality.
- Adds a request message for `AnswerUpdate`.
- Cleans the code for QuestionsRoute to abstract redundant names/strings to its own variable.